### PR TITLE
[PLAT-433] Allow using the node name as host name for datadog

### DIFF
--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -103,6 +103,11 @@ spec:
           {{- if .Values.datadog.hostname }}
           - name: DD_HOSTNAME
             value: {{ .Values.datadog.hostname | quote }}
+          {{- else if .Values.datadog.useNodeNameAsHostname }}  
+          - name: DD_HOSTNAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           {{- end }}
           {{- if .Values.datadog.acInclude }}
           - name: DD_AC_INCLUDE

--- a/stable/datadog/templates/daemonset.yaml
+++ b/stable/datadog/templates/daemonset.yaml
@@ -103,11 +103,11 @@ spec:
           {{- if .Values.datadog.hostname }}
           - name: DD_HOSTNAME
             value: {{ .Values.datadog.hostname | quote }}
-          {{- else if .Values.datadog.useNodeNameAsHostname }}  
+          {{- else if .Values.datadog.useHostIpAsHostname }}  
           - name: DD_HOSTNAME
             valueFrom:
               fieldRef:
-                fieldPath: spec.nodeName
+                fieldPath: status.hostIP
           {{- end }}
           {{- if .Values.datadog.acInclude }}
           - name: DD_AC_INCLUDE


### PR DESCRIPTION
I reached out to datadog support, and this is what they recommended if we don't want the instance ID (which is super useless for us) as the hostname for all of our EKS worker node hosts.

Eg this alert: https://iterable.slack.com/archives/C5HDS64Q7/p1550272841019900